### PR TITLE
Proxy /api requests to API backend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const store = createStore(
 )
 // sagaMiddleware.run(clockSaga)
 
-const todoClient = new TodoClient('http://localhost:8080/api')
+const todoClient = new TodoClient('/api')
 
 const AppComponent = () => (
   <Container>

--- a/src/nginx.conf
+++ b/src/nginx.conf
@@ -1,3 +1,7 @@
+upstream api {
+  server api:3000;
+}
+
 server {
   listen 80;
   
@@ -5,6 +9,14 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
     try_files $uri $uri/ /index.html =404;
+  }
+
+  location /api {
+    rewrite ^/api/(.*)$ /$1 break;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass http://api;
   }
   
   include /etc/nginx/extra-conf.d/*.conf;


### PR DESCRIPTION
 ## Description

This allows the SPA to make requests to `/api/todos` and they will be proxied to the API backend in Docker.

Note that the API backend host and port are hardcoded for now, as nginx doesn't allow the usage of environment variables easily.

 ### How to test

Steps to test :
1. Spin up the backend API by going to `overkill-todo-monolith-api` and running `docker-compose up`
2. Build and run the SPA, connecting to the API's Docker network. Something like: `docker run -p 80:80 --network="overkill-todo-monolith-api_default" todo-spa`
3. Go to http://localhost and check it loads the Todos.
