### PR TITLE
Run provider side of the pact tests as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,38 @@ jobs:
       - name: Run ci tests
         run: yarn ci
 
-  build-and-push-container:
+  provider-pact:
     runs-on: ubuntu-latest
     needs: test
+    steps:
+      - name: Checkout API code
+        uses: actions/checkout@v2
+        with:
+          path: api
+          repository: overkilling/overkill-todo-monolith-api
+      - name: Checkout SPA code
+        uses: actions/checkout@v2
+        with:
+          path: spa
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.16.1'
+      - name: Install dependencies
+        run: yarn install
+        working-directory: spa
+      - name: Generate pact
+        run: yarn pact
+        working-directory: spa
+      - name: Copies pact
+        run: cp -v spa/pacts/*.json api/pact/
+      - name: Run provider side of pact tests
+        run: PACT_URL=/pact/spa-api.json make pact
+        working-directory: api
+
+  build-and-push-container:
+    runs-on: ubuntu-latest
+    needs: [test, provider-pact]
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest --coverage",
     "test-watch": "jest --watch",
     "pact": "jest --runInBand --config jest.pact.js",
+    "pact:copy-to-infra": "cp -v pacts/*.json ../overkill-todo-infrastructure/pacts/",
     "ci": "yarn compile && yarn test && yarn pact && yarn cypress:run && yarn prettier-check && yarn lint",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
### Description

The intent is to prevent a consumer driven change from breaking production. Thus, this step will validate that the current pact tests will not break against the latest version of the API. Ideally a pact broker should be used, but in the meantime this is a reasonable tradeoff.